### PR TITLE
USR-AUTH-SOCIAL-AUTOJOIN

### DIFF
--- a/accounts/adapters.py
+++ b/accounts/adapters.py
@@ -7,25 +7,18 @@ User = get_user_model()
 
 class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
     def save_user(self, request, sociallogin: SocialLogin, form=None):
-        user = sociallogin.user
-
         provider = sociallogin.account.provider
         uid = sociallogin.account.uid
-
         extra_data = sociallogin.account.extra_data
-        nickname = extra_data.get("nickname") or extra_data.get("name") or "소셜사용자"
 
         try:
             return User.objects.get(social_type=provider, social_id=uid)
         except User.DoesNotExist:
-            pass
-
-        user = User.objects.create_social_user(
-            username=nickname,
-            social_type=provider,
-            social_id=uid,
-            email=extra_data.get("email", None),
-            profile_image=extra_data.get("picture", None),
-        )
-        sociallogin.user = user
-        return user
+            nickname = extra_data.get("nickname") or extra_data.get("name") or "소셜사용자"
+            return User.objects.create_social_user(
+                username=nickname,
+                social_type=provider,
+                social_id=uid,
+                email=extra_data.get("email"),
+                profile_image=extra_data.get("picture"),
+            )

--- a/accounts/adapters.py
+++ b/accounts/adapters.py
@@ -1,12 +1,31 @@
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
-from .tokens import generate_tokens_for_user
+from django.contrib.auth import get_user_model
+from allauth.socialaccount.models import SocialLogin
+
+User = get_user_model()
 
 
 class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
-    def login(self, request, user):
-        """
-        세션 login은 생략하고 JWT만 발급하여 request에 저장
-        """
-        access_token, refresh_token = generate_tokens_for_user(user)
-        request.jwt_access_token = access_token
-        request.jwt_refresh_token = refresh_token
+    def save_user(self, request, sociallogin: SocialLogin, form=None):
+        user = sociallogin.user
+
+        provider = sociallogin.account.provider
+        uid = sociallogin.account.uid
+
+        extra_data = sociallogin.account.extra_data
+        nickname = extra_data.get("nickname") or extra_data.get("name") or "소셜사용자"
+
+        try:
+            return User.objects.get(social_type=provider, social_id=uid)
+        except User.DoesNotExist:
+            pass
+
+        user = User.objects.create_social_user(
+            username=nickname,
+            social_type=provider,
+            social_id=uid,
+            email=extra_data.get("email", None),
+            profile_image=extra_data.get("picture", None),
+        )
+        sociallogin.user = user
+        return user

--- a/accounts/adapters.py
+++ b/accounts/adapters.py
@@ -1,0 +1,12 @@
+from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
+from .tokens import generate_tokens_for_user
+
+
+class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
+    def login(self, request, user):
+        """
+        세션 login은 생략하고 JWT만 발급하여 request에 저장
+        """
+        access_token, refresh_token = generate_tokens_for_user(user)
+        request.jwt_access_token = access_token
+        request.jwt_refresh_token = refresh_token

--- a/accounts/kakao_adapter.py
+++ b/accounts/kakao_adapter.py
@@ -1,16 +1,11 @@
-from allauth.socialaccount.providers.oauth2.views import OAuth2Adapter
+from allauth.socialaccount.providers.kakao.views import KakaoOAuth2Adapter
 from allauth.socialaccount.adapter import get_adapter
 from allauth.socialaccount.providers.kakao.provider import KakaoProvider
 
 
-class CustomKakaoOAuth2Adapter(OAuth2Adapter):
-    provider_id = KakaoProvider.id
-    access_token_url = "https://kauth.kakao.com/oauth/token"
-    authorize_url = "https://kauth.kakao.com/oauth/authorize"
-    profile_url = "https://kapi.kakao.com/v2/user/me"
-
+class CustomKakaoOAuth2Adapter(KakaoOAuth2Adapter):
     def complete_login(self, request, app, token, **kwargs):
-        access_token = token["access_token"]  # token은 dict 타입
+        access_token = token["access_token"]
         headers = {
             "Authorization": f"Bearer {access_token}",
             "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",

--- a/accounts/kakao_adapter.py
+++ b/accounts/kakao_adapter.py
@@ -1,0 +1,23 @@
+from allauth.socialaccount.providers.oauth2.views import OAuth2Adapter
+from allauth.socialaccount.adapter import get_adapter
+from allauth.socialaccount.providers.kakao.provider import KakaoProvider
+
+
+class CustomKakaoOAuth2Adapter(OAuth2Adapter):
+    provider_id = KakaoProvider.id
+    access_token_url = "https://kauth.kakao.com/oauth/token"
+    authorize_url = "https://kauth.kakao.com/oauth/authorize"
+    profile_url = "https://kapi.kakao.com/v2/user/me"
+
+    def complete_login(self, request, app, token, **kwargs):
+        access_token = token["access_token"]  # token은 dict 타입
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
+        }
+
+        response = get_adapter().get_requests_session().get(self.profile_url, headers=headers)
+        response.raise_for_status()
+        extra_data = response.json()
+
+        return self.get_provider().sociallogin_from_response(request, extra_data)

--- a/accounts/tokens.py
+++ b/accounts/tokens.py
@@ -1,0 +1,30 @@
+import jwt
+from datetime import datetime, timedelta
+from django.conf import settings
+from zoneinfo import ZoneInfo
+
+seoul_tz = ZoneInfo("Asia/Seoul")
+
+
+def generate_tokens_for_user(user):
+    now = datetime.now(tz=seoul_tz)
+
+    access_payload = {
+        "user_id": str(user.id),
+        "username": user.username,
+        "exp": now + timedelta(minutes=15),
+        "iat": now,
+        "type": "access",
+    }
+
+    refresh_payload = {
+        "user_id": str(user.id),
+        "exp": now + timedelta(days=7),
+        "iat": now,
+        "type": "refresh",
+    }
+
+    access_token = jwt.encode(access_payload, settings.SECRET_KEY, algorithm="HS256")
+    refresh_token = jwt.encode(refresh_payload, settings.SECRET_KEY, algorithm="HS256")
+
+    return access_token, refresh_token

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -97,3 +97,17 @@ class TokenRefreshView(View):
         response = JsonResponse({"message": "access token 재발급 성공"})
         response.set_cookie("access_token", new_access_token, httponly=True, samesite="Lax")
         return response
+
+
+class SocialLoginCallbackView(View):
+    def get(self, request):
+        access_token = getattr(request, "jwt_access_token", None)
+        refresh_token = getattr(request, "jwt_refresh_token", None)
+
+        if access_token is None:
+            return HttpResponseBadRequest("로그인 실패: access token 이 존재하지 않습니다.")
+
+        response = redirect("/")
+        response.set_cookie("access_token", access_token, httponly=True, samesite="Lax")
+        response.set_cookie("refresh_token", refresh_token, httponly=True, samesite="Lax")
+        return response

--- a/config/settings.py
+++ b/config/settings.py
@@ -152,6 +152,8 @@ ACCOUNT_AUTHENTICATION_METHOD = "email"
 ACCOUNT_EMAIL_VERIFICATION = "none"  # 개발 중에는 'none'
 SOCIALACCOUNT_QUERY_EMAIL = True
 
+SOCIALACCOUNT_ADAPTER = "accounts.adapters.CustomSocialAccountAdapter"
+
 
 # Internationalization
 # https://docs.djangoproject.com/en/4.2/topics/i18n/

--- a/config/settings.py
+++ b/config/settings.py
@@ -74,6 +74,8 @@ SOCIALACCOUNT_PROVIDERS = {
     },
 }
 
+SOCIALACCOUNT_ADAPTER = "accounts.adapters.CustomSocialAccountAdapter"
+
 
 ROOT_URLCONF = "config.urls"
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -53,6 +53,7 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "accounts.middleware.JWTAuthenticationMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "accounts.middleware.DisableSessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     # "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -65,13 +66,12 @@ SOCIALACCOUNT_PROVIDERS = {
     "google": {
         "SCOPE": ["profile", "email"],
         "AUTH_PARAMS": {"access_type": "online"},
-        "APP": {
-            "client_id": "61132518239-6d012e5g8shr1v3gjtbppm98ipdojnn8.apps.googleusercontent.com",
-            "secret": "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",
-            "key": "",
+    },
+    "kakao": {
+        "AUTH_PARAMS": {
+            "prompt": "login",
         },
     },
-    "kakao": {"APP": {"client_id": "70e76dc07e2f31f0960a7e11e67129d1", "secret": "", "key": ""}},
 }
 
 
@@ -131,7 +131,7 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-SITE_ID = 1
+SITE_ID = 4
 
 AUTHENTICATION_BACKENDS = (
     # 기본 로그인 백엔드
@@ -151,8 +151,6 @@ ACCOUNT_USERNAME_REQUIRED = False
 ACCOUNT_AUTHENTICATION_METHOD = "email"
 ACCOUNT_EMAIL_VERIFICATION = "none"  # 개발 중에는 'none'
 SOCIALACCOUNT_QUERY_EMAIL = True
-
-SOCIALACCOUNT_ADAPTER = "accounts.adapters.CustomSocialAccountAdapter"
 
 
 # Internationalization

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,8 +1,34 @@
 from django.contrib import admin
 from django.urls import path, include
+from accounts.views import SocialLoginCallbackView, index
+from accounts.kakao_adapter import CustomKakaoOAuth2Adapter
+from allauth.socialaccount.providers.google.views import GoogleOAuth2Adapter
+
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("", index),
     path("api/auth/", include("accounts.urls")),
+    path(
+        "accounts/social/login/callback/", SocialLoginCallbackView.as_view(), name="social_callback"
+    ),
+    path(
+        "accounts/kakao/login/callback/",
+        type(
+            "KakaoJWTCallbackView",
+            (SocialLoginCallbackView,),
+            {"adapter_class": CustomKakaoOAuth2Adapter},
+        ).as_view(),
+        name="kakao_jwt_callback",
+    ),
+    path(
+        "accounts/google/login/callback/",
+        type(
+            "GoogleJWTCallbackView",
+            (SocialLoginCallbackView,),
+            {"adapter_class": GoogleOAuth2Adapter},
+        ).as_view(),
+        name="google_jwt_callback",
+    ),
     path("accounts/", include("allauth.urls")),
 ]

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -1,0 +1,28 @@
+{% load  socialaccount %}
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Login</title>
+    </head>
+    <body>
+        <h1>🔥 이 템플릿은 account/login.html 입니다</h1>
+        <h2>Login</h2>
+        <!-- 일반 로그인 폼 -->
+        <form method="post" action="{% url 'account_login' %}">
+            {% csrf_token %}
+            {{ form.as_p }}
+            <button type="submit">로그인</button>
+        </form>
+        <hr>
+        <!-- 소셜 로그인 버튼 -->
+        <h3>소셜 계정으로 로그인</h3>
+        <a href="{% provider_login_url 'google' %}">Google로 로그인</a>
+        <a href="{% provider_login_url 'kakao' %}">Kakao로 로그인</a>
+        <hr>
+        <h3>📋 렌더링된 소셜 프로바이더 목록</h3>
+        <ul>
+            {% get_providers as social_providers %}
+            {% for provider in social_providers %}<li>{{ provider.id }}</li>{% endfor %}
+        </ul>
+    </body>
+</html>

--- a/templates/accounts/login.html
+++ b/templates/accounts/login.html
@@ -18,9 +18,5 @@
         <h3>소셜 계정으로 로그인</h3>
         <a href="{% provider_login_url 'google' %}">Google로 로그인</a>
         <a href="{% provider_login_url 'kakao' %}">Kakao로 로그인</a>
-        <script src="//accounts.google.com/gsi/client" async></script>
-        <div id="g_id_onload"
-             data-client_id="123-secret.apps.googleusercontent.com"
-             data-login_uri="{% url 'google_login_by_token' %}"></div>
     </body>
 </html>


### PR DESCRIPTION
- JWT 발급 모듈 분리
- 소셜 로그인 성공 시 콜백 뷰를 통해 JWT 를 쿠키에 발급
- admin 페이지를 제외한 세션을 모두 제거하는 미들웨어 추가
  - allauth 패키지의 oauth 를 통해 세션 로그인이 수행되는 것을 방지
- 쿨백 뷰가 socialaccount 테이블 대신 User 모델을 통해 기능을 수행하도록 수정
- 카카오 oauth 어댑터의 access token 추출 로직을 변경(allauth 어댑터 상속 및 메소드 오버라이드)